### PR TITLE
feat: add a default named exports array

### DIFF
--- a/.changeset/little-ducks-lie.md
+++ b/.changeset/little-ducks-lie.md
@@ -1,0 +1,5 @@
+---
+"@toastdotdev/mdx": patch
+---
+
+add a default state for namedExports in processMdx

--- a/packages/mdx/index.js
+++ b/packages/mdx/index.js
@@ -28,7 +28,13 @@ export const fetchMdxFromDisk = async ({ directory, extensions = ["mdx"] }) => {
 
 export const processMdx = async (
   content,
-  { filepath, namedExports, prismTheme, remarkPlugins = [], rehypePlugins = [] }
+  {
+    filepath,
+    namedExports = [],
+    prismTheme,
+    remarkPlugins = [],
+    rehypePlugins = [],
+  }
 ) => {
   return compileMdx(content, {
     filepath,


### PR DESCRIPTION
since the default case adds `meta` anyways, adding a default empty array for named exports means one less thing to include in the call unless you need it